### PR TITLE
fixing test to use problem.js instead of solution.js

### DIFF
--- a/w03/w3-r-sum-of-numbers/problem.js
+++ b/w03/w3-r-sum-of-numbers/problem.js
@@ -1,10 +1,10 @@
-/* Given two integers, which can be positive and negative, 
+/* Given two integers, which can be positive and negative,
 find the sum of all the numbers between and including a and b,
 and return the sum. If both numbers are equal return a or b.
 
 Note! a and b are not ordered!
 
-Example: 
+Example:
 getSum(1, 0) == 1   // 1 + 0 = 1
 getSum(1, 2) == 3   // 1 + 2 = 3
 getSum(0, 1) == 1   // 0 + 1 = 1
@@ -14,6 +14,7 @@ getSum(-1, 2) == 2  // -1 + 0 + 1 + 2 = 2
 */
 
 function getSum( a, b ) {
+  //your code here
 
 } // END FUNCTION
 
@@ -21,6 +22,4 @@ function getSum( a, b ) {
 module.exports = {
   getSum:getSum,
   attendance:"WORD UP"
-}
-
-
+};

--- a/w03/w3-r-sum-of-numbers/test/r-test.js
+++ b/w03/w3-r-sum-of-numbers/test/r-test.js
@@ -1,19 +1,19 @@
 var expect = require("chai").expect;
 
-var getSum = require("../solution").getSum;
-console.log(getSum.toString(), "TYLRERERKJERHKEJRHKJ")
+var getSum = require("../problem").getSum;
+console.log(getSum.toString(), "TYLRERERKJERHKEJRHKJ");
 describe("getSum warmup", function() {
   it("should return the same number if a and b are equal", function () {
-    expect(getSum(1, 1)).to.be.equal(1)
-    expect(getSum(7, 7)).to.be.equal(7)
-    expect(getSum(2928, 2928)).to.be.equal(2928)
-  })
+    expect(getSum(1, 1)).to.be.equal(1);
+    expect(getSum(7, 7)).to.be.equal(7);
+    expect(getSum(2928, 2928)).to.be.equal(2928);
+  });
 
   it("should return the addition of each number between and including a & b", function () {
-    expect(getSum(-1, 2)).to.be.equal(2)
-    expect(getSum(-10, 2)).to.be.equal(-52)
-    expect(getSum(77, -77)).to.be.equal(0)
-    expect(getSum(5, -7)).to.be.equal(-13)
-    expect(getSum(34554, 2)).to.be.equal(597006734)
-  })
-})
+    expect(getSum(-1, 2)).to.be.equal(2);
+    expect(getSum(-10, 2)).to.be.equal(-52);
+    expect(getSum(77, -77)).to.be.equal(0);
+    expect(getSum(5, -7)).to.be.equal(-13);
+    expect(getSum(34554, 2)).to.be.equal(597006734);
+  });
+});


### PR DESCRIPTION
added semi colons to r-test.js
changed the test usage of solution.js to problem.js, as problem.js is the students answer.